### PR TITLE
Fix: Prevent manifest modifications breaking auto-updates

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -383,13 +383,7 @@ else
     echo "✓ Created Claude settings"
 fi
 
-# Add installer version to manifest
-if [[ -f "$INSTALL_DIR/docs/docs_manifest.json" ]]; then
-    # Update manifest with installer version
-    jq '. + {"installer_version": "0.3.1"}' "$INSTALL_DIR/docs/docs_manifest.json" > "$INSTALL_DIR/docs/docs_manifest.json.tmp"
-    mv "$INSTALL_DIR/docs/docs_manifest.json.tmp" "$INSTALL_DIR/docs/docs_manifest.json"
-    echo "✓ Updated manifest with installer version"
-fi
+# Note: Do NOT modify docs_manifest.json - it's tracked by git and would break updates
 
 # Clean up old installations now that v0.3 is set up
 cleanup_old_installations

--- a/scripts/claude-docs-helper.sh.template
+++ b/scripts/claude-docs-helper.sh.template
@@ -51,9 +51,30 @@ auto_update() {
     local BEHIND=$(git rev-list HEAD..origin/"$BRANCH" --count 2>/dev/null || echo "0")
     
     if [[ "$LOCAL" != "$REMOTE" ]] && [[ "$BEHIND" -gt 0 ]]; then
-        # We're behind - safe to pull
+        # We're behind - need to update
         echo "🔄 Updating documentation..." >&2
-        git pull --quiet origin "$BRANCH" 2>&1 | grep -v "Merge made by" || true
+        
+        # Check for local changes
+        if [[ -n "$(git status --porcelain 2>/dev/null)" ]]; then
+            # Local changes detected - handle them gracefully
+            # Try to stash changes first
+            if git stash push -m "Auto-stash before update $(date)" >/dev/null 2>&1; then
+                # Pull updates
+                if git pull --quiet origin "$BRANCH" 2>&1 | grep -v "Merge made by"; then
+                    # Try to restore stashed changes
+                    git stash pop >/dev/null 2>&1 || true
+                else
+                    # Pull failed, try reset approach
+                    git reset --hard origin/"$BRANCH" >/dev/null 2>&1
+                fi
+            else
+                # Stash failed, just reset to remote
+                git reset --hard origin/"$BRANCH" >/dev/null 2>&1
+            fi
+        else
+            # No local changes, normal pull
+            git pull --quiet origin "$BRANCH" 2>&1 | grep -v "Merge made by" || true
+        fi
         
         # Check if installer needs updating
         local INSTALLER_VERSION=$(jq -r '.installer_version // "0.2"' "$MANIFEST" 2>/dev/null)


### PR DESCRIPTION
## Summary
- Fixed installer adding `installer_version` to tracked manifest file
- Updated helper script to handle dirty working directories gracefully
- All v0.3.1 users affected by broken auto-updates are now fixed

## Problem
The v0.3.1 installer was modifying `docs_manifest.json` by adding an `installer_version` field. Since this file is tracked by git, it created local changes that prevented `git pull` from working in the auto-update mechanism. This affected ALL users who installed v0.3.1.

## Solution
1. **Removed the problematic code** from `install.sh` that was adding the field
2. **Enhanced the helper script** to handle dirty working directories:
   - Checks for local changes before pulling
   - Uses `git stash` to temporarily save changes
   - Falls back to `git reset --hard` if needed
   - Ensures updates always succeed

## Test Plan
- [x] Verified the fix handles dirty manifest files
- [x] Tested auto-update still works with clean repos
- [x] Confirmed installer no longer modifies manifest

This fixes the issue reported where users saw:
```
error: Your local changes to the following files would be overwritten by merge:
        docs/docs_manifest.json
```

🤖 Generated with [Claude Code](https://claude.ai/code)