### PR TITLE
Title: Update install.sh to run on fresh environments when no prior installs are found

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -13,6 +13,9 @@ INSTALL_DIR="$HOME/.claude-code-docs"
 # Branch to use for installation
 INSTALL_BRANCH="main"
 
+# Initialize global arrays to avoid unbound errors under set -u
+OLD_INSTALLATIONS=()
+
 # Detect OS type
 if [[ "$OSTYPE" == "darwin"* ]]; then
     OS_TYPE="macos"
@@ -40,7 +43,7 @@ echo "✓ All dependencies satisfied"
 
 # Function to find existing installations from configs
 find_existing_installations() {
-    local paths=()
+    local -a paths=()
     
     # Check command file for paths
     if [[ -f ~/.claude/commands/docs.md ]]; then
@@ -108,8 +111,10 @@ find_existing_installations() {
         paths+=("$(pwd)")
     fi
     
-    # Deduplicate and exclude new location
-    printf '%s\n' "${paths[@]}" | grep -v "^$INSTALL_DIR$" | sort -u
+    # Deduplicate and exclude new location (guard empty/unset array)
+    if [[ ${#paths[@]-0} -gt 0 ]]; then
+        printf '%s\n' "${paths[@]}" | grep -v "^$INSTALL_DIR$" | sort -u
+    fi
 }
 
 # Function to migrate from old location
@@ -339,7 +344,12 @@ existing_installs=()
 while IFS= read -r line; do
     [[ -n "$line" ]] && existing_installs+=("$line")
 done < <(find_existing_installations)
-OLD_INSTALLATIONS=("${existing_installs[@]}")  # Save for later cleanup
+# Save for later cleanup, guard empty expansion under set -u
+if [[ ${#existing_installs[@]} -gt 0 ]]; then
+    OLD_INSTALLATIONS=("${existing_installs[@]}")
+else
+    OLD_INSTALLATIONS=()
+fi
 
 if [[ ${#existing_installs[@]} -gt 0 ]]; then
     echo "Found ${#existing_installs[@]} existing installation(s):"


### PR DESCRIPTION
fix(install): guard array expansions under set -u to prevent unbound variable errors

Description:
- Root cause: `set -u` with unguarded array expansions (`paths[@]`, `existing_installs[@]`) caused “unbound variable” errors when arrays were unset/empty.
- Changes in `install.sh`:
  - Initialize `OLD_INSTALLATIONS=()` near the top.
  - Declare `paths` as an array with `local -a` in `find_existing_installations`.
  - Guard `paths` printing with a length check before `printf`.
  - Guard assignment to `OLD_INSTALLATIONS` from `existing_installs`; fallback to empty when none.
- Impact: Installer runs clean on fresh environments and when no prior installs are found. No behavior change otherwise.

Test plan:
- Fresh run on macOS with no `~/.claude-code-docs`: completes install without errors.
- Run with existing repo in a different path: migrates/updates successfully and prints available topics.
- Verify `/docs` command file and `~/.claude/settings.json` hook are created/updated.

DK Note:
The way this came about is I tried to **install** ccd using the `To update:` bash command shown in the README => got a couple of unbound variable errors (prob cuz I was installing and not updating) => used Cursor to fix => re-ran bash command => confirmed successful install.