### PR TITLE
Handle installation error if there is no existing installs

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -109,7 +109,9 @@ find_existing_installations() {
     fi
     
     # Deduplicate and exclude new location
-    printf '%s\n' "${paths[@]}" | grep -v "^$INSTALL_DIR$" | sort -u
+    if [[ ${#paths[@]} -gt 0 ]]; then
+        printf '%s\n' "${paths[@]}" | grep -v "^$INSTALL_DIR$" | sort -u
+    fi
 }
 
 # Function to migrate from old location
@@ -339,9 +341,11 @@ existing_installs=()
 while IFS= read -r line; do
     [[ -n "$line" ]] && existing_installs+=("$line")
 done < <(find_existing_installations)
-OLD_INSTALLATIONS=("${existing_installs[@]}")  # Save for later cleanup
 
+# Initialize OLD_INSTALLATIONS and mark all of them for cleanup
+OLD_INSTALLATIONS=()
 if [[ ${#existing_installs[@]} -gt 0 ]]; then
+    OLD_INSTALLATIONS=("${existing_installs[@]}")
     echo "Found ${#existing_installs[@]} existing installation(s):"
     for install in "${existing_installs[@]}"; do
         echo "  - $install"


### PR DESCRIPTION
### Issue

- When doing your first install the install script fails because the `paths` and `existing_installs` are empty because there are no existing installs

```bash
Checking for existing installations...
bash: line 112: paths[@]: unbound variable
bash: line 342: existing_installs[@]: unbound variable
```

### Fixes
- Add array length check for `paths` before doing the `printf` in `find_existing_installations()` function
- Initialize OLD_INSTALLATIONS to avoid unbound variable errors
- Move the setting of `OLD_INSTALLATIONS=("${existing_installs[@]}")` into the `existing_installs` length check block