### PR TITLE
Fix bash array expansion errors when arrays are empty

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -109,7 +109,9 @@ find_existing_installations() {
     fi
     
     # Deduplicate and exclude new location
-    printf '%s\n' "${paths[@]}" | grep -v "^$INSTALL_DIR$" | sort -u
+    if [[ ${#paths[@]} -gt 0 ]]; then
+        printf '%s\n' "${paths[@]}" | grep -v "^$INSTALL_DIR$" | sort -u
+    fi
 }
 
 # Function to migrate from old location
@@ -339,7 +341,11 @@ existing_installs=()
 while IFS= read -r line; do
     [[ -n "$line" ]] && existing_installs+=("$line")
 done < <(find_existing_installations)
-OLD_INSTALLATIONS=("${existing_installs[@]}")  # Save for later cleanup
+if [[ ${#existing_installs[@]} -gt 0 ]]; then
+    OLD_INSTALLATIONS=("${existing_installs[@]}")  # Save for later cleanup
+else
+    OLD_INSTALLATIONS=()  # Initialize empty array
+fi
 
 if [[ ${#existing_installs[@]} -gt 0 ]]; then
     echo "Found ${#existing_installs[@]} existing installation(s):"


### PR DESCRIPTION
## Summary
- Fixes installer script failing with "unbound variable" errors on lines 112 and 342
- Occurs when running with `set -u` and attempting to expand empty arrays
- Common scenario for fresh installations

## Problem
The installer was failing with these errors:
```bash
bash: line 112: paths[@]: unbound variable
bash: line 342: existing_installs[@]: unbound variable
```

This happens because the script uses `set -u` (treat unset variables as errors) and tries to expand arrays that might be empty using `"${array[@]}"` syntax.

## Solution
Added proper guards to check if arrays have elements before attempting to expand them:
- **Line 112**: Check if `paths` array has elements before `printf` expansion
- **Line 342**: Initialize `OLD_INSTALLATIONS` as empty array when `existing_installs` is empty

## Test plan
- [x] Tested fresh installation on macOS - works correctly
- [x] Script completes successfully without errors
- [x] Documentation installs to `~/.claude-code-docs` as expected

## Reproduction
Before this fix, running the installer on a fresh system:
```bash
curl -fsSL https://raw.githubusercontent.com/ericbuess/claude-code-docs/main/install.sh | bash
```

Would fail with the unbound variable errors shown above.

After this fix, the installer completes successfully.

🤖 Generated with [Claude Code](https://claude.ai/code)