### PR TITLE
Fix unbound variable errors when arrays are empty in install.sh Fixes #28

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -109,7 +109,9 @@ find_existing_installations() {
     fi
     
     # Deduplicate and exclude new location
-    printf '%s\n' "${paths[@]}" | grep -v "^$INSTALL_DIR$" | sort -u
+    if [[ ${#paths[@]} -gt 0 ]]; then
+        printf '%s\n' "${paths[@]}" | grep -v "^$INSTALL_DIR$" | sort -u
+    fi
 }
 
 # Function to migrate from old location
@@ -297,7 +299,7 @@ safe_git_update() {
 # Function to cleanup old installations
 cleanup_old_installations() {
     # Use the global OLD_INSTALLATIONS array that was populated before config updates
-    if [[ ${#OLD_INSTALLATIONS[@]} -eq 0 ]]; then
+    if [[ -z "${OLD_INSTALLATIONS+x}" ]] || [[ ${#OLD_INSTALLATIONS[@]} -eq 0 ]]; then
         return
     fi
     
@@ -339,7 +341,11 @@ existing_installs=()
 while IFS= read -r line; do
     [[ -n "$line" ]] && existing_installs+=("$line")
 done < <(find_existing_installations)
-OLD_INSTALLATIONS=("${existing_installs[@]}")  # Save for later cleanup
+if [[ ${#existing_installs[@]} -gt 0 ]]; then
+    OLD_INSTALLATIONS=("${existing_installs[@]}")  # Save for later cleanup
+else
+    OLD_INSTALLATIONS=()  # Initialize as empty array
+fi
 
 if [[ ${#existing_installs[@]} -gt 0 ]]; then
     echo "Found ${#existing_installs[@]} existing installation(s):"


### PR DESCRIPTION
### Summary
This PR fixes unbound variable errors that occur when the installer script encounters empty arrays. The script uses `set -euo pipefail` which causes bash to exit when trying to expand empty arrays.

### Problem
When no existing installations are found, the script fails with:
- `line 112: paths[@]: unbound variable`
- `line 342: existing_installs[@]: unbound variable`

### Solution
Added proper checks before expanding potentially empty arrays:

1. **Line 111-113**: Check if `paths` array has elements before printing
2. **Line 342-346**: Conditionally initialize `OLD_INSTALLATIONS` array
3. **Line 300**: Added check to ensure `OLD_INSTALLATIONS` is defined before accessing

### Testing
- ✅ Tested with no existing installations (fresh install)
- ✅ Tested with existing installations (migration scenario)
- ✅ Script completes successfully in both cases

### Changes Made
```diff
# Line 111-113
-    printf '%s\n' "${paths[@]}" | grep -v "^$INSTALL_DIR$" | sort -u
+    if [[ ${#paths[@]} -gt 0 ]]; then
+        printf '%s\n' "${paths[@]}" | grep -v "^$INSTALL_DIR$" | sort -u
+    fi

# Line 342-346
-OLD_INSTALLATIONS=("${existing_installs[@]}")
+if [[ ${#existing_installs[@]} -gt 0 ]]; then
+    OLD_INSTALLATIONS=("${existing_installs[@]}")
+else
+    OLD_INSTALLATIONS=()
+fi

# Line 300
-    if [[ ${#OLD_INSTALLATIONS[@]} -eq 0 ]]; then
+    if [[ -z "${OLD_INSTALLATIONS+x}" ]] || [[ ${#OLD_INSTALLATIONS[@]} -eq 0 ]]; then
```

Fixes #28